### PR TITLE
Fix nested response arrays

### DIFF
--- a/lib/cardconnect_sdk/attributable.rb
+++ b/lib/cardconnect_sdk/attributable.rb
@@ -45,7 +45,7 @@ module Attributable
     end
 
     def from_json(json)
-      self.new(JSON.parse(json).symbolize_keys)
+      self.new(JSON.parse(json).deep_symbolize_keys)
     end
   end
 end

--- a/lib/cardconnect_sdk/deposit/ach_deposit.rb
+++ b/lib/cardconnect_sdk/deposit/ach_deposit.rb
@@ -9,17 +9,13 @@ module CardconnectSdk
       attr_reader :txns
 
       def initialize(attrs={})
-        attrs.symbolize_keys!
+        attrs.deep_symbolize_keys!
         txns = attrs.delete(:txns)
 
         super(attrs)
 
         unpack_txns(txns)
       end
-
-      # def self.from_json(json)
-      #   self.new(JSON.parse(json))
-      # end
 
       private
 

--- a/lib/cardconnect_sdk/deposit/response.rb
+++ b/lib/cardconnect_sdk/deposit/response.rb
@@ -12,6 +12,8 @@ module CardconnectSdk
         end
       end
 
+      # Overridden because the json returns an array instead of
+      # a typical hash, so deep_stringify_keys would fail.
       def self.from_json(json)
         self.new(JSON.parse(json))
       end

--- a/lib/cardconnect_sdk/funding/response.rb
+++ b/lib/cardconnect_sdk/funding/response.rb
@@ -8,7 +8,7 @@ module CardconnectSdk
       attr_reader :txns, :fundings, :adjustments
 
       def initialize(attrs={})
-        attrs.symbolize_keys!
+        attrs.deep_symbolize_keys!
         txns        = attrs.delete(:txns)
         fundings    = attrs.delete(:fundings)
         adjustments = attrs.delete(:adjustments)
@@ -18,10 +18,6 @@ module CardconnectSdk
         unpack_txns(txns)
         unpack_fundings(fundings)
         unpack_adjustments(adjustments)
-      end
-
-      def self.from_json(json)
-        self.new(JSON.parse(json))
       end
 
       private

--- a/lib/cardconnect_sdk/profile/response.rb
+++ b/lib/cardconnect_sdk/profile/response.rb
@@ -5,17 +5,21 @@ module CardconnectSdk
 
       attr_reader :profileid, :accounts
 
-      def initialize(json)
-        # inflate accounts from json
-        @accounts = JSON.parse(json).map { |a| Account.new(a.symbolize_keys) }
-      end
-
-      def self.from_json(json)
-        self.new(json)
+      def initialize(accounts=[])
+        @accounts = []
+        accounts.each do |account|
+          @accounts << Account.new(account.deep_symbolize_keys)
+        end
       end
 
       def profileid
         @profileid ||= accounts.first.profileid rescue ''
+      end
+
+      # Overridden because the json returns an array instead of
+      # a typical hash, so deep_stringify_keys would fail.
+      def self.from_json(json)
+        self.new(JSON.parse(json))
       end
     end
   end

--- a/lib/cardconnect_sdk/settlement_status/batch.rb
+++ b/lib/cardconnect_sdk/settlement_status/batch.rb
@@ -8,7 +8,7 @@ module CardconnectSdk
       attr_reader :txns
 
       def initialize(attrs={})
-        attrs.symbolize_keys!
+        attrs.deep_symbolize_keys!
         txns = attrs.delete(:txns)
 
         super(attrs)

--- a/lib/cardconnect_sdk/settlement_status/response.rb
+++ b/lib/cardconnect_sdk/settlement_status/response.rb
@@ -12,6 +12,8 @@ module CardconnectSdk
         end
       end
 
+      # Overridden because the json returns an array instead of
+      # a typical hash, so deep_stringify_keys would fail.
       def self.from_json(json)
         self.new(JSON.parse(json))
       end

--- a/spec/lib/cardconnect_sdk/client_spec.rb
+++ b/spec/lib/cardconnect_sdk/client_spec.rb
@@ -176,6 +176,7 @@ module CardconnectSdk
 
             txn = batch.txns.first
             expect(txn).to be_a(CardconnectSdk::SettlementStatus::Transaction)
+            expect(txn.retref).to match(/^[0-9]+$/)
           end
         end
       end
@@ -192,6 +193,7 @@ module CardconnectSdk
 
             txn = deposit.txns.first
             expect(txn).to be_a(CardconnectSdk::Deposit::Transaction)
+            expect(txn.retref).to match(/^[0-9]+$/)
           end
         end
       end
@@ -205,14 +207,17 @@ module CardconnectSdk
             expect(res.txns).to be_a(Array)            
             txn = res.txns.first
             expect(txn).to be_a(CardconnectSdk::Funding::Transaction)
+            expect(txn.retref).to match(/^[0-9]+$/)
 
             expect(res.fundings).to be_a(Array)
             funding = res.fundings.first
             expect(funding).to be_a(CardconnectSdk::Funding::FundingNode)
+            expect(funding.fundingid).to match(/^[0-9]+$/)
 
             expect(res.adjustments).to be_a(Array)
             adjustment = res.adjustments.first
             expect(adjustment).to be_a(CardconnectSdk::Funding::Adjustment)
+            expect(adjustment.fundingadjustmentid).to match(/^[0-9]+$/)
           end
         end
       end


### PR DESCRIPTION
Bug fix for nested response arrays, where symbolize_keys wasn't affecting nested hashes from the parsed JSON.