### PR TITLE
Added card_bank_accepted method and changed use of settlement query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+*1.2.0* (April 30, 2015)
+
+* Changed meaning of settled and added card_bank_accepted.  Settled now determines whether a decision has been made (accepted or declined). The card_bank_accepted method tells you whether the issuing bank will accept the request.
+
 *1.1.0* (April 29, 2015)
 
 * Can distinguish between CardConnect declines and Card Processor declines

--- a/lib/cardconnect_sdk/authorization/response.rb
+++ b/lib/cardconnect_sdk/authorization/response.rb
@@ -7,6 +7,10 @@ module CardconnectSdk
       attr_reader :respstat, :account, :token, :retref, :amount, :merchid, :commcard,
                   :respcode, :resptext, :avsresp, :cvvresp, :authcode, :respproc,
                   :batchid
+
+      def settled?
+        false
+      end
     end
   end
 end

--- a/lib/cardconnect_sdk/capture/response.rb
+++ b/lib/cardconnect_sdk/capture/response.rb
@@ -7,6 +7,9 @@ module CardconnectSdk
       attr_reader :amount, :setlstat, :retref, :merchid, :account,
                   :respcode, :resptext, :respproc, :respstat, :batchid
 
+      def settled?
+        false
+      end
     end
   end
 end

--- a/lib/cardconnect_sdk/settlement_status/transaction.rb
+++ b/lib/cardconnect_sdk/settlement_status/transaction.rb
@@ -6,6 +6,10 @@ module CardconnectSdk
       attr_reader :setlstat, :retref
       
       def settled?
+        setlstat == 'Y' || setlstat == 'N'
+      end
+
+      def card_bank_accepted?
         setlstat == 'Y'
       end
     end

--- a/lib/cardconnect_sdk/version.rb
+++ b/lib/cardconnect_sdk/version.rb
@@ -1,3 +1,3 @@
 module CardconnectSdk
-VERSION = "1.1.0"
+VERSION = "1.2.0"
 end

--- a/spec/lib/cardconnect_sdk/authorization/response_spec.rb
+++ b/spec/lib/cardconnect_sdk/authorization/response_spec.rb
@@ -9,6 +9,10 @@ module CardconnectSdk
         capture = described_class.new(respstat: 'A', capture: 'Y', batchid: '1234')
         expect(capture.batchid).to_not be_empty
       end
+
+      it 'has not settled' do
+        expect(described_class.new).to_not be_settled
+      end
     end
   end
 end

--- a/spec/lib/cardconnect_sdk/capture/response_spec.rb
+++ b/spec/lib/cardconnect_sdk/capture/response_spec.rb
@@ -9,6 +9,10 @@ module CardconnectSdk
         capture = described_class.new(respstat: 'A', batchid: '1234')
         expect(capture.batchid).to_not be_empty
       end
+
+      it 'has not settled' do
+        expect(described_class.new).to_not be_settled
+      end
     end
   end
 end

--- a/spec/lib/cardconnect_sdk/settlement_status/transaction_spec.rb
+++ b/spec/lib/cardconnect_sdk/settlement_status/transaction_spec.rb
@@ -10,14 +10,24 @@ module CardconnectSdk
           let(:instance) { described_class.new(setlstat: 'Y') }
 
           it { expect(instance).to be_settled }
+          it { expect(instance).to be_card_bank_accepted }
         end
 
-        context "#when setlstat != 'Y'" do
+        context "#when setlstat == 'N'" do
           let(:instance) { described_class.new(setlstat: 'N') }
+
+          it { expect(instance).to be_settled }
+          it { expect(instance).to_not be_card_bank_accepted }
+        end
+
+        context "#when setlstat != 'Y' or 'N'" do
+          let(:instance) { described_class.new(setlstat: 'R') }
           
           it { expect(instance).to_not be_settled }
+          it { expect(instance).to_not be_card_bank_accepted }
         end
       end
+
     end
   end
 end


### PR DESCRIPTION
Added card_bank_accepted method to settlement transaction and expanded use of settlement method.  This allows us to treat Authorization, Capture and Settlement Transaction responses the same way in VB without have to use respond_to? methods.
