### PR TITLE
Settlement status handles empty results

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+*1.7.0* (May 06, 2015)
+
+* Settlment status handles empty results
+
 *1.6.0* (May 05, 2015)
 
 * Changed settlement status. Supports status by merchant only, by date and by batch ID.

--- a/lib/cardconnect_sdk/settlement_status/response.rb
+++ b/lib/cardconnect_sdk/settlement_status/response.rb
@@ -15,27 +15,14 @@ module CardconnectSdk
       # Overridden because the json returns an array instead of
       # a typical hash, so deep_stringify_keys would fail.
       def self.from_json(json)
+        return self.new if empty?(json)
         self.new(JSON.parse(json))
+      end
+
+      def self.empty?(json)
+        true if json.include?('Null')
       end
 
     end
   end
 end
-
-# [
-#   {
-#     "txns": [
-#       {
-#         "setlstat": "N",
-#         "retref": "179001161341"
-#       },
-#       {
-#         "setlstat": "Y",
-#         "retref": "179002161341"
-#       }
-#     ],
-#     "batchid": "71742042",
-#     "hoststat": "GB",
-#     "hostbatch": "71742041"
-#   }
-# ]

--- a/lib/cardconnect_sdk/version.rb
+++ b/lib/cardconnect_sdk/version.rb
@@ -1,3 +1,3 @@
 module CardconnectSdk
-VERSION = "1.6.0"
+VERSION = "1.7.0"
 end

--- a/spec/cassettes/CardconnectSdk_Client/_requests/_settlement_status/_settlement_status_transaction/returns_empty_settlement_status.yml
+++ b/spec/cassettes/CardconnectSdk_Client/_requests/_settlement_status/_settlement_status_transaction/returns_empty_settlement_status.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://testing:testing123@fts.prinpay.com:6443/cardconnect/rest/settlestat?merchid=496160873888
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      X-Frame-Options:
+      - DENY
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '12'
+      Date:
+      - Wed, 06 May 2015 16:54:48 GMT
+      Set-Cookie:
+      - cardconnect=!2gZPJ9GuPRqyPdytAPhzJKhZZVF6qrGjJzSrHwKZbcwvyrm7YZU6i/9nb/6weeRGA2gepQSFyPCjs/0=;
+        path=/
+    body:
+      encoding: UTF-8
+      string: Null batches
+    http_version: 
+  recorded_at: Wed, 06 May 2015 16:54:47 GMT
+recorded_with: VCR 2.9.3

--- a/spec/lib/cardconnect_sdk/client_spec.rb
+++ b/spec/lib/cardconnect_sdk/client_spec.rb
@@ -168,7 +168,7 @@ module CardconnectSdk
       end
 
       context '#settlement_status', :vcr do
-        context '.settlement_status_transaction', focus:true do
+        context '.settlement_status_transaction' do
           it 'returns settlement status for a batch' do
             req = CardconnectSdk::SettlementStatus::Request.new(merchid: ENV['CARDCONNECT_MERCHANT_ID'], batchid: '1900940041')
             res = instance.settlement_status_for_batch(req)
@@ -207,6 +207,13 @@ module CardconnectSdk
             txn = batch.txns.first
             expect(txn).to be_a(CardconnectSdk::SettlementStatus::Transaction)
             expect(txn.retref).to match(/^[0-9]+$/)
+          end
+
+          it 'returns empty settlement status' do
+            req = CardconnectSdk::SettlementStatus::Request.new(merchid: ENV['CARDCONNECT_MERCHANT_ID'])
+            res = instance.settlement_status_for_merchant(req)
+            expect(res.batches).to be_a(Array)
+            expect(res.batches).to be_empty
           end
         end
       end

--- a/spec/lib/cardconnect_sdk/settlement_status/request_spec.rb
+++ b/spec/lib/cardconnect_sdk/settlement_status/request_spec.rb
@@ -27,7 +27,7 @@ module CardconnectSdk
           end
         end
 
-        context 'status for specifiec batch' do
+        context 'status for specific batch' do
           it 'can request status for a batch' do
             req = described_class.new(merchid: ENV['CARDCONNECT_MERCHANT_ID'], batchid: 'abc123')
             expect(req.merchid).to eq(ENV['CARDCONNECT_MERCHANT_ID'])

--- a/spec/lib/cardconnect_sdk/settlement_status/response_spec.rb
+++ b/spec/lib/cardconnect_sdk/settlement_status/response_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module CardconnectSdk
+  module SettlementStatus
+    RSpec.describe Response, type: :lib do
+     settlement_json_response =  <<-SETTLEMENT_JSON
+[
+  {
+    "txns": [
+      {
+        "setlstat": "N",
+        "retref": "179001161341"
+      },
+      {
+        "setlstat": "Y",
+        "retref": "179002161341"
+      }
+    ],
+    "batchid": "71742042",
+    "hoststat": "GB",
+    "hostbatch": "71742041"
+  }
+]
+      SETTLEMENT_JSON
+
+      context '.from_json' do
+        it 'handles proper json' do
+          response = described_class.from_json(settlement_json_response)
+          expect(response.batches).to be_an(Array)
+          expect(response.batches.count).to eql(1)
+        end
+
+        it 'handles no results' do
+          response = described_class.from_json('Null batches')
+          expect(response.batches).to be_an(Array)
+          expect(response.batches).to be_empty
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
When there are no updated settlement statuses since last query CardConnect returns a string 'Null batches' instead of an empty array.  The sdk now addresses that.
